### PR TITLE
Update multidraw.cpp

### DIFF
--- a/src/main/cpp/gl/multidraw.cpp
+++ b/src/main/cpp/gl/multidraw.cpp
@@ -456,7 +456,6 @@ GLAPI GLAPIENTRY void mg_glMultiDrawElementsBaseVertex_compute(
         GLES.glGenBuffers(1, &g_prefixsumbuffer);
         GLES.glGenBuffers(1, &g_firstidx_ssbo);
         GLES.glGenBuffers(1, &g_basevtx_ssbo);
-        GLES.glGenBuffers(1, &g_prefixsumbuffer);
         GLES.glGenBuffers(1, &g_outputibo);
 
         g_compute_program = compile_compute_program(multidraw_comp_shader);


### PR DESCRIPTION
"The line GLES.glGenBuffers(1, &g_prefixsumbuffer); was prevented from being written twice."