### PR TITLE
[Fix] (texture): Swizzle BGRA to RGBA for glTexSubImage2D

### DIFF
--- a/MobileGlues-cpp/gl/texture.cpp
+++ b/MobileGlues-cpp/gl/texture.cpp
@@ -990,7 +990,10 @@ void glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, G
           glEnumToString(target), level, xoffset, yoffset, width, height, glEnumToString(format), glEnumToString(type),
           pixels)
 
-    if (format == GL_BGRA && type == GL_UNSIGNED_INT_8_8_8_8) {
+    if (format == GL_BGRA && (type == GL_UNSIGNED_INT_8_8_8_8 || type == GL_UNSIGNED_INT_8_8_8_8_REV)) {
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_R,  GL_BLUE);
+        glTexParameteri(target, GL_TEXTURE_SWIZZLE_B,  GL_RED);
+
         format = GL_RGBA;
         type = GL_UNSIGNED_BYTE;
     }


### PR DESCRIPTION
Workaround for LWJGL3ify SDL using BGRA.