### PR TITLE
[Fix] (egl): bigGL args filtering to ES

### DIFF
--- a/MobileGlues-cpp/egl/egl.cpp
+++ b/MobileGlues-cpp/egl/egl.cpp
@@ -63,7 +63,24 @@ extern "C"
               "%d, num_config: %p",
               dpy, attrib_list, configs, config_size, num_config);
         LOAD_EGL(eglChooseConfig)
-        return egl_eglChooseConfig(dpy, attrib_list, configs, config_size, num_config);
+        EGLint attribs[64];
+        if (attrib_list) {
+            LOG_D("attrib_list:")
+            int i = 0;
+            while (attrib_list[i] != EGL_NONE) {
+                attribs[i]     = attrib_list[i];
+                attribs[i + 1] = attrib_list[i + 1];
+                if (attribs[i] == EGL_RENDERABLE_TYPE)
+                    attribs[i + 1] = EGL_OPENGL_ES3_BIT;
+                LOG_D("  attr=0x%04X value=%d", attribs[i], attribs[i+1]);
+                i += 2;
+            }
+            attribs[i] = EGL_NONE;
+            LOG_D("  EGL_NONE");
+        } else {
+            LOG_D("attrib_list = NULL");
+        }
+        return egl_eglChooseConfig(dpy, attribs, configs, config_size, num_config);
     }
 
     EGL_API EGLBoolean eglGetConfigAttrib(EGLDisplay dpy, EGLConfig config, EGLint attribute, EGLint* value) {
@@ -76,6 +93,19 @@ extern "C"
                                               const EGLint* attrib_list) {
         LOG_D("eglCreateWindowSurface, dpy: %p, config: %p, win: %p, attrib_list: %p", dpy, config, win, attrib_list);
         LOAD_EGL(eglCreateWindowSurface)
+        EGLint attribs[64];
+        if (attrib_list) {
+            LOG_D("attrib_list:")
+            int i = 0;
+            while (attrib_list[i] != EGL_NONE) {
+                LOG_D("  attr=0x%04X value=%d", attribs[i], attribs[i+1]);
+                i += 2;
+            }
+            attribs[i] = EGL_NONE;
+            LOG_D("  EGL_NONE");
+        } else {
+            LOG_D("attrib_list = NULL");
+        }
         return egl_eglCreateWindowSurface(dpy, config, win, attrib_list);
     }
 
@@ -107,6 +137,7 @@ extern "C"
     }
 
     EGL_API EGLBoolean eglBindAPI(EGLenum api) {
+        api = EGL_OPENGL_ES_API;
         LOG_D("eglBindAPI, api: %d", api);
         LOAD_EGL(eglBindAPI)
         return egl_eglBindAPI(api);
@@ -169,7 +200,11 @@ extern "C"
               "attrib_list: %p",
               dpy, config, share_context, attrib_list);
         LOAD_EGL(eglCreateContext)
-        return egl_eglCreateContext(dpy, config, share_context, attrib_list);
+        EGLint contextAttribs[] = {
+                EGL_CONTEXT_CLIENT_VERSION, 3,
+                EGL_NONE
+        };
+        return egl_eglCreateContext(dpy, config, share_context, contextAttribs);
     }
 
     EGL_API EGLBoolean eglDestroyContext(EGLDisplay dpy, EGLContext ctx) {

--- a/MobileGlues-cpp/gl/gl_native.cpp
+++ b/MobileGlues-cpp/gl/gl_native.cpp
@@ -57,7 +57,6 @@ NATIVE_FUNCTION_HEAD(void, glDisable, GLenum cap) NATIVE_FUNCTION_END_NO_RETURN(
 NATIVE_FUNCTION_HEAD(void, glDisableVertexAttribArray, GLuint index) NATIVE_FUNCTION_END_NO_RETURN(void, glDisableVertexAttribArray, index)
 NATIVE_FUNCTION_HEAD(void, glDrawArrays, GLenum mode, GLint first, GLsizei count) NATIVE_FUNCTION_END_NO_RETURN(void, glDrawArrays, mode,first,count)
 //NATIVE_FUNCTION_HEAD(void, glDrawElements, GLenum mode, GLsizei count, GLenum type, const void *indices) NATIVE_FUNCTION_END_NO_RETURN(void, glDrawElements, mode,count,type,indices)
-NATIVE_FUNCTION_HEAD(void, glEnable, GLenum cap) NATIVE_FUNCTION_END_NO_RETURN(void, glEnable, cap)
 NATIVE_FUNCTION_HEAD(void, glEnableVertexAttribArray, GLuint index) NATIVE_FUNCTION_END_NO_RETURN(void, glEnableVertexAttribArray, index)
 NATIVE_FUNCTION_HEAD(void, glFinish) NATIVE_FUNCTION_END_NO_RETURN(void, glFinish)
 NATIVE_FUNCTION_HEAD(void, glFlush) NATIVE_FUNCTION_END_NO_RETURN(void, glFlush)
@@ -371,3 +370,23 @@ NATIVE_FUNCTION_HEAD(void, glGetSamplerParameterIuiv, GLuint sampler, GLenum pna
 //NATIVE_FUNCTION_HEAD(void, glTexBufferRange, GLenum target, GLenum internalformat, GLuint buffer, GLintptr offset, GLsizeiptr size) NATIVE_FUNCTION_END_NO_RETURN(void, glTexBufferRange, target,internalformat,buffer,offset,size)
 NATIVE_FUNCTION_HEAD(void, glTexStorage3DMultisample, GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations) NATIVE_FUNCTION_END_NO_RETURN(void, glTexStorage3DMultisample, target,samples,internalformat,width,height,depth,fixedsamplelocations)
 //NATIVE_FUNCTION_HEAD(void*, glMapBufferRange, GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access) NATIVE_FUNCTION_END(void*, glMapBufferRange, target,offset,length,access)
+
+// Jank, needed for 26.3-snapshot4+ as it deliberately calls GL_PROGRAM_POINT_SIZE and
+// GL_TEXTURE_CUBE_MAP_SEAMLESS in Minecraft code
+NATIVE_FUNCTION_HEAD(void, glEnable, GLenum cap)
+    LOG_D("Use native function: %s @ %s(...)", RENDERERNAME, __FUNCTION__)
+    switch (cap) {
+        case GL_PROGRAM_POINT_SIZE:
+        case GL_TEXTURE_CUBE_MAP_SEAMLESS:
+        case GL_FRAMEBUFFER_SRGB:
+        case GL_SAMPLE_SHADING:
+        case GL_DEBUG_OUTPUT:
+        case GL_DEBUG_OUTPUT_SYNCHRONOUS:
+            LOG_D("Desktop GLenum passed, ignoring call %s(%s)", __FUNCTION__, glEnumToString(cap))
+            return;
+        default:
+            break;
+    }
+    GLES.glEnable(cap);
+    CHECK_GL_ERROR
+}


### PR DESCRIPTION
This is a bit cringe and hardcoded but it gets 26.3-snapshot4 to run it seems