### PR TITLE
[Fix] (texture): map GL_DEPTH_COMPONENT32 to GL_DEPTH_COMPONENT32F for GLES

### DIFF
--- a/MobileGlues-cpp/gl/texture.cpp
+++ b/MobileGlues-cpp/gl/texture.cpp
@@ -268,8 +268,11 @@ void internal_convert(GLenum* internal_format, GLenum* type, GLenum* format) {
         if (type) *type = GL_UNSIGNED_INT;
         break;
     case GL_DEPTH_COMPONENT32:
-        *internal_format = GL_DEPTH_COMPONENT;
-        if (type) *type = GL_UNSIGNED_INT;
+        // Legacy desktop-GL 32-bit UNORM depth has no GLES equivalent, and the
+        // unsized GL_DEPTH_COMPONENT fallback is rejected by glTexStorage2D
+        // (sized formats required). Promote to DEPTH_COMPONENT32F instead.
+        *internal_format = GL_DEPTH_COMPONENT32F;
+        if (type) *type = GL_FLOAT;
         break;
     case GL_DEPTH_COMPONENT32F:
         if (type) *type = GL_FLOAT;
@@ -738,6 +741,7 @@ static int is_depth_format(GLenum format) {
     case GL_DEPTH_COMPONENT:
     case GL_DEPTH_COMPONENT16:
     case GL_DEPTH_COMPONENT24:
+    case GL_DEPTH_COMPONENT32:
     case GL_DEPTH_COMPONENT32F:
         return 1;
     default:


### PR DESCRIPTION
Maps the desktop-GL internal format `GL_DEPTH_COMPONENT32` (0x81A7) to `GL_DEPTH_COMPONENT32F` in `internal_convert()`, and adds it to `is_depth_format()`. Without this, Minecraft 26.x cannot allocate its main depth texture through MobileGlues.

## Why

Minecraft 26.x (`GlDevice.createTexture` in the new blaze3d GL device) allocates its depth attachment with:

```
glTexImage2D(target, 0, GL_DEPTH_COMPONENT32 /* 33191 */, w, h, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL)
```

`GL_DEPTH_COMPONENT32` is a desktop GL sized format that does not exist in GLES 3.x, so the call fails (`GL_INVALID_ENUM`/`GL_INVALID_OPERATION` depending on driver) and the game bails out during framebuffer creation. The closest GLES 3.0 sized depth format is `GL_DEPTH_COMPONENT32F`, which requires `type = GL_FLOAT` — the type Minecraft already passes; the conversion forces it regardless for safety.

Found while getting Minecraft 26.1.2 running in Amethyst (PojavLauncher iOS successor), but the format mapping applies to any platform where MobileGlues backs a desktop-GL app.

## Testing

- Built via the Amethyst-iOS CI (Xcode 26.3, iOS SDK) and run on an iPad Pro (iPadOS 26.5) with Minecraft 26.1.2: depth texture allocation no longer errors. (On iOS this also needs the companion Apple symbol-lookup fix, PR'd separately.)
- Minecraft 1.21.x unaffected (uses `GL_DEPTH_COMPONENT24` path).