### PR TITLE
[Fix] (glx): resolve GL symbols via RTLD_SELF, not RTLD_NEXT, on Apple

### DIFF
--- a/MobileGlues-cpp/glx/lookup.cpp
+++ b/MobileGlues-cpp/glx/lookup.cpp
@@ -55,7 +55,13 @@ void* glXGetProcAddress(const char* name) {
     LOG()
     std::string real_func_name = handle_multidraw_func_name(std::string(name));
 #ifdef __APPLE__
-    return dlsym((void*)(~(uintptr_t)0), real_func_name.c_str());
+    // (void*)~0 is RTLD_NEXT on Darwin: "search images AFTER the caller",
+    // which skips libmobileglues itself and hands the app raw ANGLE entry
+    // points, bypassing every GL translation wrapper. RTLD_SELF starts the
+    // search in this image so the exported wrappers win; the internal GLES
+    // backend table still resolves through to ANGLE (gles/loader.cpp), so
+    // wrapper -> ANGLE calls do not recurse.
+    return dlsym(RTLD_SELF, real_func_name.c_str());
 #else
 
     void* proc = nullptr;


### PR DESCRIPTION
On Apple platforms, `glXGetProcAddress` resolved symbols with `dlsym((void*)~(uintptr_t)0, ...)`. On Darwin that magic handle is **RTLD_NEXT** — "search images loaded *after* the calling image" — which skips `libmobileglues` itself. The result: every function pointer handed back to the app (e.g. LWJGL's `GLFWGetProcAddress` path) was a raw ANGLE/GLES entry point, and the entire MobileGlues translation layer was silently bypassed on iOS. No `mg_*` wrappers, no multidraw emulation, no format conversion — apps were effectively talking straight to ANGLE while appearing to run on MobileGlues.

This switches the lookup to **RTLD_SELF** ("search starting at the calling image"), so the exported wrapper symbols in `libmobileglues` win. No recursion risk: the internal backend dispatch table is populated directly from the GLES library via `gles/loader.cpp`, not through `glXGetProcAddress`, so wrapper → backend calls still go straight to ANGLE.

## How this was found

While getting Minecraft 26.1.2 running in Amethyst (PojavLauncher iOS successor): a fix to MobileGlues' texture format conversion had no observable effect, and Minecraft kept receiving raw `GL_INVALID_OPERATION` errors that MobileGlues' error-swallowing wrappers should have intercepted. Logging confirmed the wrappers were never called — the returned pointers were ANGLE's own exports.

## Testing

- Built via Amethyst-iOS CI (Xcode 26.3) and run on iPad Pro, iPadOS 26.5: MobileGlues wrappers now actually execute on iOS (log output appears, format fixups take effect).
- Non-Apple platforms untouched (`#ifdef __APPLE__` branch only).

Companion fix (found once the layer was genuinely active): #49.